### PR TITLE
use memory pressure percentage as 95%

### DIFF
--- a/pressure_memory_analysis_continuous.c
+++ b/pressure_memory_analysis_continuous.c
@@ -12,7 +12,7 @@
 size_t MEM_SIZE = 16777216;
 
 /* Pressure percentage */
-float MEM_PRESSURE = 0.99;
+float MEM_PRESSURE = 0.95;
 
 bool RELEASE_FLAG = true;
 bool FLAG = false;

--- a/pressure_memory_analysis_random.c
+++ b/pressure_memory_analysis_random.c
@@ -15,7 +15,7 @@
 size_t MEM_SIZE = 16777216;
 
 /* Pressure percentage */
-float MEM_PRESSURE = 0.99;
+float MEM_PRESSURE = 0.95;
 
 bool RELEASE_FLAG = true;
 bool FLAG = false;


### PR DESCRIPTION
The test got killed if the memory pressure percentage is 99 percent
so reduce the pressure environment to 95 percent

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>